### PR TITLE
fix for AttributeError: 'HTMLParser' object has no attribute 'unescape'

### DIFF
--- a/plugin.video.cartoonsgr/resources/lib/modules/client.py
+++ b/plugin.video.cartoonsgr/resources/lib/modules/client.py
@@ -414,6 +414,11 @@ def parseDOM(html, name='', attrs=None, ret=False):
 
 def replaceHTMLCodes(txt):
     # txt = re.sub("(&#[0-9]+)([^;^0-9]+)", "\\1;\\2", txt)
+    if six.PY3:
+        import html
+        txt = html.unescape(txt)
+    else:
+        txt = HTMLParser.HTMLParser().unescape(txt)
     txt = HTMLParser.HTMLParser().unescape(txt)
     txt = txt.replace("&quot;", "\"")
     txt = txt.replace("&amp;", "&")

--- a/plugin.video.cartoonsgr/resources/lib/modules/client.py
+++ b/plugin.video.cartoonsgr/resources/lib/modules/client.py
@@ -26,7 +26,7 @@ from resources.lib.modules import cache, dom_parser, control, utils
 
 import six
 from six import BytesIO
-from six.moves import urllib, urllib_parse, html_parser as HTMLParser
+from six.moves import urllib, urllib_parse
 from six.moves.urllib_parse import quote_plus, urlencode, urlparse
 from six.moves.urllib_response import addinfourl
 if six.PY3:
@@ -418,6 +418,7 @@ def replaceHTMLCodes(txt):
         import html
         txt = html.unescape(txt)
     else:
+        from six.moves import html_parser as HTMLParser
         txt = HTMLParser.HTMLParser().unescape(txt)
     txt = HTMLParser.HTMLParser().unescape(txt)
     txt = txt.replace("&quot;", "\"")


### PR DESCRIPTION
 Fix CartoonsGR for the "AttributeError: 'HTMLParser' object has no attribute 'unescape'" error on some linux based Kodi Matrix systems