### PR TITLE
fix for AttributeError: 'HTMLParser' object has no attribute 'unescape'

### DIFF
--- a/plugin.video.cartoonsgr/resources/lib/modules/client.py
+++ b/plugin.video.cartoonsgr/resources/lib/modules/client.py
@@ -414,7 +414,11 @@ def parseDOM(html, name='', attrs=None, ret=False):
 
 def replaceHTMLCodes(txt):
     # txt = re.sub("(&#[0-9]+)([^;^0-9]+)", "\\1;\\2", txt)
-    txt = HTMLParser.HTMLParser().unescape(txt)
+    if six.PY3:
+        import html
+        txt = html.unescape(txt)
+    else:
+        txt = HTMLParser.HTMLParser().unescape(txt)
     txt = txt.replace("&quot;", "\"")
     txt = txt.replace("&amp;", "&")
     txt = txt.replace("&lt;", "<")


### PR DESCRIPTION
Fix for CartoonsGR v.1.0.25 for error "AttributeError: 'HTMLParser' object has no attribute 'unescape'" on some linux based Kodi Matrix systems